### PR TITLE
Version safe nuget loader

### DIFF
--- a/Doki.sln
+++ b/Doki.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doki.TestAssembly", "tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doki.Tests.Common", "tests\Doki.Tests.Common\Doki.Tests.Common.csproj", "{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doki.CommandLine.Tests", "tests\Doki.CommandLine.Tests\Doki.CommandLine.Tests.csproj", "{67B12AF1-2696-411F-ADFD-B5C32A43BA71}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,7 @@ Global
 		{6CCD9EE6-B3FC-485F-9155-553165141B20} = {8C7B5305-B599-4F08-B28B-DD9F1715DD51}
 		{0293D689-DFDC-4A78-80D8-BFC11DB0A175} = {08041208-BE3D-4BE8-9AF7-806B73985275}
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC} = {8C7B5305-B599-4F08-B28B-DD9F1715DD51}
+		{67B12AF1-2696-411F-ADFD-B5C32A43BA71} = {8C7B5305-B599-4F08-B28B-DD9F1715DD51}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6F31B87A-2BD3-4FB4-8C08-7E059A338D4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -110,5 +113,9 @@ Global
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67B12AF1-2696-411F-ADFD-B5C32A43BA71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67B12AF1-2696-411F-ADFD-B5C32A43BA71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67B12AF1-2696-411F-ADFD-B5C32A43BA71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67B12AF1-2696-411F-ADFD-B5C32A43BA71}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Doki.CommandLine/Commands/GenerateCommand.Outputs.cs
+++ b/src/Doki.CommandLine/Commands/GenerateCommand.Outputs.cs
@@ -34,7 +34,7 @@ internal partial class GenerateCommand
 
         var nugetFolder = Path.Combine(workingDirectory.FullName, ".doki", "nuget");
 
-        using var nugetLoader = new NuGetLoader(output.From);
+        using var nugetLoader = new NuGetLoader(_logger, output.From);
 
         var assemblyPath =
             await nugetLoader.LoadPackageAsync(output.Type, nugetFolder, allowPreview, cancellationToken);

--- a/src/Doki.CommandLine/Doki.CommandLine.csproj
+++ b/src/Doki.CommandLine/Doki.CommandLine.csproj
@@ -22,17 +22,21 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Doki.CommandLine.Tests"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="NuGet.Resolver" Version="6.9.1" />
+        <PackageReference Include="NuGet.Resolver" Version="6.9.1"/>
         <PackageReference Include="Spectre.Console" Version="0.48.0"/>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Doki.Output.Extensions\Doki.Output.Extensions.csproj" />
+        <ProjectReference Include="..\Doki.Output.Extensions\Doki.Output.Extensions.csproj"/>
         <ProjectReference Include="..\Doki\Doki.csproj"/>
     </ItemGroup>
 

--- a/src/Doki.CommandLine/NuGet/NuGetLoader.cs
+++ b/src/Doki.CommandLine/NuGet/NuGetLoader.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using Microsoft.Extensions.DependencyModel;
-using NuGet.Common;
+﻿using Microsoft.Extensions.DependencyModel;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;

--- a/src/Doki.CommandLine/NuGet/NuGetLoader.cs
+++ b/src/Doki.CommandLine/NuGet/NuGetLoader.cs
@@ -17,12 +17,13 @@ internal class NuGetLoader : IDisposable
 {
     private readonly SourceCacheContext _cacheContext = new();
 
-    //TODO use console logger (ASCII)
-    private readonly ILogger _logger = NullLogger.Instance;
+    private readonly NuGetLogger _logger;
     private readonly SourceRepositoryProvider _sourceRepositoryProvider;
 
-    public NuGetLoader(string? source = null)
+    public NuGetLoader(Microsoft.Extensions.Logging.ILogger logger, string? source = null)
     {
+        _logger = new NuGetLogger(logger);
+
         var sources = new List<PackageSource>
         {
             new("https://api.nuget.org/v3/index.json")

--- a/src/Doki.CommandLine/NuGet/NuGetLogger.cs
+++ b/src/Doki.CommandLine/NuGet/NuGetLogger.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using ILogger = NuGet.Common.ILogger;
+using LogLevel = NuGet.Common.LogLevel;
+
+namespace Doki.CommandLine.NuGet;
+
+internal class NuGetLogger(Microsoft.Extensions.Logging.ILogger logger) : ILogger
+{
+    public void LogDebug(string data)
+    {
+        logger.LogDebug(data);
+    }
+
+    public void LogVerbose(string data)
+    {
+        logger.LogTrace(data);
+    }
+
+    public void LogInformation(string data)
+    {
+        logger.LogInformation(data);
+    }
+
+    public void LogMinimal(string data)
+    {
+        logger.LogInformation(data);
+    }
+
+    public void LogWarning(string data)
+    {
+        logger.LogWarning(data);
+    }
+
+    public void LogError(string data)
+    {
+        logger.LogError(data);
+    }
+
+    public void LogInformationSummary(string data)
+    {
+        logger.LogInformation(data);
+    }
+
+    public void Log(LogLevel level, string data)
+    {
+        switch (level)
+        {
+            case LogLevel.Debug:
+                LogDebug(data);
+                break;
+            case LogLevel.Verbose:
+                LogVerbose(data);
+                break;
+            case LogLevel.Information:
+                LogInformation(data);
+                break;
+            case LogLevel.Minimal:
+                LogMinimal(data);
+                break;
+            case LogLevel.Warning:
+                LogWarning(data);
+                break;
+            case LogLevel.Error:
+                LogError(data);
+                break;
+        }
+    }
+
+    public Task LogAsync(LogLevel level, string data)
+    {
+        Log(level, data);
+        return Task.CompletedTask;
+    }
+
+    public void Log(ILogMessage message)
+    {
+        Log(message.Level, message.Message);
+    }
+
+    public Task LogAsync(ILogMessage message)
+    {
+        return LogAsync(message.Level, message.Message);
+    }
+}

--- a/tests/Doki.CommandLine.Tests/Doki.CommandLine.Tests.csproj
+++ b/tests/Doki.CommandLine.Tests/Doki.CommandLine.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Doki.CommandLine\Doki.CommandLine.csproj" />
+      <ProjectReference Include="..\Doki.Tests.Common\Doki.Tests.Common.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Doki.CommandLine.Tests/GlobalUsings.cs
+++ b/tests/Doki.CommandLine.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Doki.CommandLine.Tests/NuGetTests.cs
+++ b/tests/Doki.CommandLine.Tests/NuGetTests.cs
@@ -1,0 +1,27 @@
+using Doki.CommandLine.NuGet;
+using Doki.Tests.Common;
+using Xunit.Abstractions;
+
+namespace Doki.CommandLine.Tests;
+
+public class NuGetTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task NuGetLoader_TestAsync()
+    {
+        const string packageId = "Doki.Output.Json";
+        var tmpDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        var logger = new TestOutputLogger(testOutputHelper);
+
+        using var loader = new NuGetLoader(logger);
+
+        await loader.LoadPackageAsync(packageId, tmpDirectory);
+
+        Assert.False(logger.HadError);
+
+        var dllPath = Path.Combine(tmpDirectory, $"{packageId}.1.0.0", "lib", "net8.0", $"{packageId}.dll");
+
+        Assert.True(File.Exists(dllPath));
+    }
+}


### PR DESCRIPTION
This feature introduces a version safe NuGet loader.

Specificly this impact the `doki g` generate command. With theses changes it will only load output nuget packages which have matching common doki dependencies. (e.g. `Doki.Abstractions`, `Doki.Output.Abstractions`, etc.)