### PR TITLE
Release 2.0

### DIFF
--- a/Doki.sln
+++ b/Doki.sln
@@ -34,6 +34,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doki.TestAssembly", "tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doki.Tests.Common", "tests\Doki.Tests.Common\Doki.Tests.Common.csproj", "{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Doki.Extensions", "src\Doki.Extensions\Doki.Extensions.csproj", "{9961F717-DBD7-4987-9E68-2B85BB5830B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -110,5 +112,9 @@ Global
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FA0FF7A-6EDA-4CB1-8D81-2DFB1A4077CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9961F717-DBD7-4987-9E68-2B85BB5830B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9961F717-DBD7-4987-9E68-2B85BB5830B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9961F717-DBD7-4987-9E68-2B85BB5830B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9961F717-DBD7-4987-9E68-2B85BB5830B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/docs/api/Doki.Abstractions/Doki/Doki.MemberDocumentation.md
+++ b/docs/api/Doki.Abstractions/Doki/Doki.MemberDocumentation.md
@@ -40,7 +40,9 @@ Implements: [System.IEquatable&lt;Doki.MemberDocumentation&gt;](https://learn.mi
 |Name| Gets the name of the member.|
 |Namespace| Gets the namespace of the member.|
 |Assembly| Gets the assembly of the member.|
-|Summary| Gets the summary of the member.|
+|Summaries| Gets the summary of the member.|
+|Examples| Get the examples of the member.|
+|Remarks| Gets the remarks of the member.|
 |IsDocumented| Gets a value indicating whether the type is documented.|
 |ContentType||
 

--- a/docs/api/Doki.Abstractions/Doki/Doki.TypeDocumentation.md
+++ b/docs/api/Doki.Abstractions/Doki/Doki.TypeDocumentation.md
@@ -35,8 +35,6 @@ Implements: [System.IEquatable&lt;Doki.TypeDocumentation&gt;](https://learn.micr
 |---|---|
 |EqualityContract||
 |Definition| Gets the definition of the type.|
-|Examples| Get the examples of the type.|
-|Remarks| Gets the remarks of the type.|
 |Interfaces| Gets the interfaces implemented by the type.|
 |DerivedTypes| Gets the derived types of the type.|
 |Constructors| Gets the constructors of the type.|

--- a/docs/api/Doki.Extensions/Doki.Extensions/Doki.Extensions.DocumentationObjectExtensions.md
+++ b/docs/api/Doki.Extensions/Doki.Extensions/Doki.Extensions.DocumentationObjectExtensions.md
@@ -1,0 +1,27 @@
+[Packages](../../README.md) / [Doki.Extensions](../README.md) / [Doki.Extensions](README.md) / 
+
+# DocumentationObjectExtensions Class
+
+## Definition
+
+Namespace: [Doki.Extensions](README.md)
+
+Assembly: [Doki.Extensions.dll](../README.md)
+
+Package: [Doki.Extensions](https://www.nuget.org/packages/Doki.Extensions)
+
+---
+
+```csharp
+public static class DocumentationObjectExtensions
+```
+
+Inheritance: [System.Object](https://learn.microsoft.com/en-us/dotnet/api/System.Object) → DocumentationObjectExtensions
+
+## Methods
+
+|   |Summary|
+|---|---|
+|TryGetParent(Doki.DocumentationRoot, Doki.DocumentationObject)||
+
+

--- a/docs/api/Doki.Extensions/Doki.Extensions/README.md
+++ b/docs/api/Doki.Extensions/Doki.Extensions/README.md
@@ -1,0 +1,7 @@
+# Doki.Extensions Namespace
+
+## Types
+
+- [DocumentationObjectExtensions](Doki.Extensions.DocumentationObjectExtensions.md)
+
+

--- a/docs/api/Doki.Extensions/README.md
+++ b/docs/api/Doki.Extensions/README.md
@@ -1,0 +1,9 @@
+# Doki.Extensions
+
+Provides extensions for Doki documentation generation
+
+## Namespaces
+
+- [Doki.Extensions](Doki.Extensions/README.md)
+
+

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -8,6 +8,10 @@
   
   Provides abstractions for Doki documentation generation
 
+- [Doki.Extensions](Doki.Extensions/README.md)
+  
+  Provides extensions for Doki documentation generation
+
 - [Doki.Output.Abstractions](Doki.Output.Abstractions/README.md)
   
   Provides abstractions for Doki output generation

--- a/src/Doki.Abstractions/MemberDocumentation.cs
+++ b/src/Doki.Abstractions/MemberDocumentation.cs
@@ -1,4 +1,5 @@
-﻿namespace Doki;
+﻿// ReSharper disable InconsistentNaming
+namespace Doki;
 
 /// <summary>
 /// Represents the documentation for a member.
@@ -20,10 +21,38 @@ public record MemberDocumentation : DocumentationObject
     /// </summary>
     public string? Assembly { get; init; }
 
+    internal XmlDocumentation[] InternalSummaries = [];
+
     /// <summary>
     /// Gets the summary of the member.
     /// </summary>
-    public XmlDocumentation? Summary { get; set; }
+    public XmlDocumentation[] Summaries
+    {
+        get => InternalSummaries;
+        init => InternalSummaries = value;
+    }
+
+    internal XmlDocumentation[] InternalExamples = [];
+
+    /// <summary>
+    /// Get the examples of the member.
+    /// </summary>
+    public XmlDocumentation[] Examples
+    {
+        get => InternalExamples;
+        init => InternalExamples = value;
+    }
+
+    internal XmlDocumentation[] InternalRemarks = [];
+
+    /// <summary>
+    /// Gets the remarks of the member.
+    /// </summary>
+    public XmlDocumentation[] Remarks
+    {
+        get => InternalRemarks;
+        init => InternalRemarks = value;
+    }
 
     /// <summary>
     /// Gets a value indicating whether the type is documented.

--- a/src/Doki.Abstractions/TypeDocumentation.cs
+++ b/src/Doki.Abstractions/TypeDocumentation.cs
@@ -10,28 +10,6 @@ public sealed record TypeDocumentation : TypeDocumentationReference
     /// </summary>
     public string Definition { get; init; } = null!;
 
-    internal XmlDocumentation[] InternalExamples = [];
-
-    /// <summary>
-    /// Get the examples of the type.
-    /// </summary>
-    public XmlDocumentation[] Examples
-    {
-        get => InternalExamples;
-        init => InternalExamples = value;
-    }
-
-    internal XmlDocumentation[] InternalRemarks = [];
-
-    /// <summary>
-    /// Gets the remarks of the type.
-    /// </summary>
-    public XmlDocumentation[] Remarks
-    {
-        get => InternalRemarks;
-        init => InternalRemarks = value;
-    }
-
     internal TypeDocumentationReference[] InternalInterfaces = [];
 
     /// <summary>

--- a/src/Doki.Extensions/DocumentationObjectExtensions.cs
+++ b/src/Doki.Extensions/DocumentationObjectExtensions.cs
@@ -34,17 +34,48 @@ public static class DocumentationObjectExtensions
                 var field = SearchParentIn(typeDocumentation.Fields, to);
                 if (field != null) return field;
 
-                var example = SearchParentIn(typeDocumentation.Examples, to);
-                if (example != null) return example;
-
-                var remarks = SearchParentIn(typeDocumentation.Remarks, to);
-                if (remarks != null) return remarks;
-
                 var interfaceDocumentation = SearchParentIn(typeDocumentation.Interfaces, to);
                 if (interfaceDocumentation != null) return interfaceDocumentation;
 
                 var derivedType = SearchParentIn(typeDocumentation.DerivedTypes, to);
                 if (derivedType != null) return derivedType;
+
+                var result = SearchParentInTypeDocumentationReference(typeDocumentation, to);
+                if (result != null) return result;
+
+                break;
+            }
+            case GenericTypeArgumentDocumentation genericTypeArgumentDocumentation:
+            {
+                if (genericTypeArgumentDocumentation.Description != null)
+                {
+                    var description = SearchParent(genericTypeArgumentDocumentation.Description, to);
+                    if (description != null) return description;
+                }
+
+                var result = SearchParentInTypeDocumentationReference(genericTypeArgumentDocumentation, to);
+                if (result != null) return result;
+
+                break;
+            }
+            case TypeDocumentationReference typeDocumentationReference:
+            {
+                var result = SearchParentInTypeDocumentationReference(typeDocumentationReference, to);
+                if (result != null) return result;
+
+                break;
+            }
+            case MemberDocumentation memberDocumentation:
+            {
+                var result = SearchParentInMemberDocumentation(memberDocumentation, to);
+                if (result != null) return result;
+
+                break;
+            }
+            case XmlDocumentation xmlDocumentation:
+            {
+                var result = SearchParentIn(xmlDocumentation.Contents, to);
+                if (result != null) return result;
 
                 break;
             }
@@ -65,12 +96,18 @@ public static class DocumentationObjectExtensions
         var genericArgument = SearchParentIn(typeDocumentationReference.GenericArguments, to);
         return genericArgument ?? SearchParentInMemberDocumentation(typeDocumentationReference, to);
     }
-    
+
     private static DocumentationObject? SearchParentInMemberDocumentation(MemberDocumentation memberDocumentation,
         DocumentationObject to)
     {
-        var summary = SearchParentIn(memberDocumentation.Summary, to);
-        return summary ?? SearchParentIn(memberDocumentation.Remarks, to);
+        var summary = SearchParentIn(memberDocumentation.Summaries, to);
+        if (summary != null) return summary;
+
+        var remarks = SearchParentIn(memberDocumentation.Remarks, to);
+        if (remarks != null) return remarks;
+
+        var example = SearchParentIn(memberDocumentation.Examples, to);
+        return example;
     }
 
     private static DocumentationObject? SearchParentIn(IEnumerable<DocumentationObject> children,

--- a/src/Doki.Extensions/DocumentationObjectExtensions.cs
+++ b/src/Doki.Extensions/DocumentationObjectExtensions.cs
@@ -1,0 +1,81 @@
+﻿namespace Doki.Extensions;
+
+public static class DocumentationObjectExtensions
+{
+    public static DocumentationObject? TryGetParent(this DocumentationRoot root, DocumentationObject child)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(child);
+
+        return child.Parent ?? SearchParent(root, child);
+    }
+
+    private static DocumentationObject? SearchParent(DocumentationObject from, DocumentationObject to)
+    {
+        if (from == to) return from;
+
+        switch (from)
+        {
+            case DocumentationRoot root: return SearchParentIn(root.Assemblies, to);
+            case AssemblyDocumentation assemblyDocumentation:
+                return SearchParentIn(assemblyDocumentation.Namespaces, to);
+            case NamespaceDocumentation namespaceDocumentation: return SearchParentIn(namespaceDocumentation.Types, to);
+            case TypeDocumentation typeDocumentation:
+            {
+                var constructor = SearchParentIn(typeDocumentation.Constructors, to);
+                if (constructor != null) return constructor;
+
+                var method = SearchParentIn(typeDocumentation.Methods, to);
+                if (method != null) return method;
+
+                var property = SearchParentIn(typeDocumentation.Properties, to);
+                if (property != null) return property;
+
+                var field = SearchParentIn(typeDocumentation.Fields, to);
+                if (field != null) return field;
+
+                var example = SearchParentIn(typeDocumentation.Examples, to);
+                if (example != null) return example;
+
+                var remarks = SearchParentIn(typeDocumentation.Remarks, to);
+                if (remarks != null) return remarks;
+
+                var interfaceDocumentation = SearchParentIn(typeDocumentation.Interfaces, to);
+                if (interfaceDocumentation != null) return interfaceDocumentation;
+
+                var derivedType = SearchParentIn(typeDocumentation.DerivedTypes, to);
+                if (derivedType != null) return derivedType;
+
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private static DocumentationObject? SearchParentInTypeDocumentationReference(
+        TypeDocumentationReference typeDocumentationReference, DocumentationObject to)
+    {
+        if (typeDocumentationReference.BaseType != null)
+        {
+            var baseType = SearchParent(typeDocumentationReference.BaseType, to);
+            if (baseType != null) return baseType;
+        }
+
+        var genericArgument = SearchParentIn(typeDocumentationReference.GenericArguments, to);
+        return genericArgument ?? SearchParentInMemberDocumentation(typeDocumentationReference, to);
+    }
+    
+    private static DocumentationObject? SearchParentInMemberDocumentation(MemberDocumentation memberDocumentation,
+        DocumentationObject to)
+    {
+        var summary = SearchParentIn(memberDocumentation.Summary, to);
+        return summary ?? SearchParentIn(memberDocumentation.Remarks, to);
+    }
+
+    private static DocumentationObject? SearchParentIn(IEnumerable<DocumentationObject> children,
+        DocumentationObject to)
+    {
+        return children.Select(child => SearchParent(child, to)).OfType<DocumentationObject>().FirstOrDefault();
+    }
+}

--- a/src/Doki.Extensions/Doki.Extensions.csproj
+++ b/src/Doki.Extensions/Doki.Extensions.csproj
@@ -14,7 +14,6 @@
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RootNamespace>Doki</RootNamespace>
         <PackageOutputPath>..\..\nuget</PackageOutputPath>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/src/Doki.Extensions/Doki.Extensions.csproj
+++ b/src/Doki.Extensions/Doki.Extensions.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <PackageId>Doki.Extensions</PackageId>
+        <Authors>david@vollmers.org</Authors>
+        <Copyright>David Vollmers</Copyright>
+        <Description>Provides extensions for Doki documentation generation</Description>
+        <PackageProjectUrl>https://github.com/DavidVollmers/doki</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>logo-64x64.png</PackageIcon>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/DavidVollmers/doki.git</RepositoryUrl>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>Doki</RootNamespace>
+        <PackageOutputPath>..\..\nuget</PackageOutputPath>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\"/>
+        <None Include="..\..\assets\logo-64x64.png" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Doki.Abstractions\Doki.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Doki.Output.Markdown/MarkdownOutput.cs
+++ b/src/Doki.Output.Markdown/MarkdownOutput.cs
@@ -216,7 +216,6 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
                 foreach (var summary in constructor.Summaries)
                 {
                     text.Append(markdown.BuildText(summary));
-                    text.NewLine();
                 }
 
                 table.AddRow(new Text(constructor.Name), text);
@@ -236,9 +235,8 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
                 foreach (var summary in field.Summaries)
                 {
                     text.Append(markdown.BuildText(summary));
-                    text.NewLine();
                 }
-                
+
                 table.AddRow(new Text(field.Name), text);
             }
 
@@ -256,7 +254,6 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
                 foreach (var summary in property.Summaries)
                 {
                     text.Append(markdown.BuildText(summary));
-                    text.NewLine();
                 }
 
                 table.AddRow(new Text(property.Name), text);
@@ -276,7 +273,6 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
                 foreach (var summary in method.Summaries)
                 {
                     text.Append(markdown.BuildText(summary));
-                    text.NewLine();
                 }
 
                 table.AddRow(new Text(method.Name), text);

--- a/src/Doki.Output.Markdown/MarkdownOutput.cs
+++ b/src/Doki.Output.Markdown/MarkdownOutput.cs
@@ -115,11 +115,14 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
 
         markdown.Add(Element.Separator);
 
-        if (typeDocumentation.Summary != null)
+        if (typeDocumentation.Summaries.Length != 0)
         {
-            var summary = markdown.BuildText(typeDocumentation.Summary);
-            summary.IsBold = true;
-            markdown.Add(summary);
+            foreach (var summary in typeDocumentation.Summaries)
+            {
+                var text = markdown.BuildText(summary);
+                text.IsBold = true;
+                markdown.Add(text);
+            }
         }
 
         markdown.Add(new Code(typeDocumentation.Definition));
@@ -209,8 +212,14 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
             var table = new Table(new Text("   "), new Text("Summary"));
             foreach (var constructor in typeDocumentation.Constructors)
             {
-                table.AddRow(new Text(constructor.Name),
-                    constructor.Summary == null ? Text.Empty : markdown.BuildText(constructor.Summary));
+                var text = Text.Empty;
+                foreach (var summary in constructor.Summaries)
+                {
+                    text.Append(markdown.BuildText(summary));
+                    text.NewLine();
+                }
+
+                table.AddRow(new Text(constructor.Name), text);
             }
 
             markdown.Add(table);
@@ -223,8 +232,14 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
             var table = new Table(new Text("   "), new Text("Summary"));
             foreach (var field in typeDocumentation.Fields)
             {
-                table.AddRow(new Text(field.Name),
-                    field.Summary == null ? Text.Empty : markdown.BuildText(field.Summary));
+                var text = Text.Empty;
+                foreach (var summary in field.Summaries)
+                {
+                    text.Append(markdown.BuildText(summary));
+                    text.NewLine();
+                }
+                
+                table.AddRow(new Text(field.Name), text);
             }
 
             markdown.Add(table);
@@ -237,8 +252,14 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
             var table = new Table(new Text("   "), new Text("Summary"));
             foreach (var property in typeDocumentation.Properties)
             {
-                table.AddRow(new Text(property.Name),
-                    property.Summary == null ? Text.Empty : markdown.BuildText(property.Summary));
+                var text = Text.Empty;
+                foreach (var summary in property.Summaries)
+                {
+                    text.Append(markdown.BuildText(summary));
+                    text.NewLine();
+                }
+
+                table.AddRow(new Text(property.Name), text);
             }
 
             markdown.Add(table);
@@ -251,8 +272,14 @@ public sealed class MarkdownOutput(OutputOptions<MarkdownOutput> options) : IOut
             var table = new Table(new Text("   "), new Text("Summary"));
             foreach (var method in typeDocumentation.Methods)
             {
-                table.AddRow(new Text(method.Name),
-                    method.Summary == null ? Text.Empty : markdown.BuildText(method.Summary));
+                var text = Text.Empty;
+                foreach (var summary in method.Summaries)
+                {
+                    text.Append(markdown.BuildText(summary));
+                    text.NewLine();
+                }
+
+                table.AddRow(new Text(method.Name), text);
             }
 
             markdown.Add(table);

--- a/tests/Doki.Output.Json.Tests/JsonOutputTests.cs
+++ b/tests/Doki.Output.Json.Tests/JsonOutputTests.cs
@@ -100,7 +100,7 @@ public class JsonOutputTests
                         Assert.Equal("Object", typeDocumentation.BaseType.Name);
                         Assert.Equal("System", typeDocumentation.BaseType.Namespace);
                         Assert.Equal("System.Private.CoreLib", typeDocumentation.BaseType.Assembly);
-                        Assert.Null(typeDocumentation.BaseType.Summary);
+                        Assert.Empty(typeDocumentation.BaseType.Summaries);
                         Assert.Equal(DocumentationContentType.TypeReference, typeDocumentation.BaseType.ContentType);
                         Assert.Equal("System.Object", typeDocumentation.BaseType.Id);
 
@@ -113,45 +113,49 @@ public class JsonOutputTests
                                     memberDocumentation.Namespace);
                                 Assert.Equal("Doki.TestAssembly.InheritanceChain.Abstractions",
                                     memberDocumentation.Assembly);
-                                Assert.Null(memberDocumentation.Summary);
+                                Assert.Empty(memberDocumentation.Summaries);
                                 Assert.Equal(DocumentationContentType.Constructor, memberDocumentation.ContentType);
                                 Assert.Equal("Doki.TestAssembly.InheritanceChain.Abstractions.AbstractClass.#ctor",
                                     memberDocumentation.Id);
                             });
 
-                        Assert.NotNull(typeDocumentation.Summary);
-                        Assert.Equal("summary", typeDocumentation.Summary.Name);
-                        Assert.Equal("summary", typeDocumentation.Summary.Id);
-                        Assert.Equal(DocumentationContentType.Xml, typeDocumentation.Summary.ContentType);
-                        Assert.Collection(typeDocumentation.Summary.Contents,
-                            documentationObject =>
+                        Assert.Collection(typeDocumentation.Summaries,
+                            summary =>
                             {
-                                Assert.NotNull(documentationObject);
-                                Assert.IsType<TextContent>(documentationObject);
-                                var textContent = (TextContent)documentationObject;
-                                Assert.Equal("This is an abstract class. See", textContent.Text);
-                                Assert.Equal(DocumentationContentType.Text, documentationObject.ContentType);
-                                Assert.Equal("text", documentationObject.Id);
-                            },
-                            documentationObject =>
-                            {
-                                Assert.NotNull(documentationObject);
-                                Assert.IsType<TypeDocumentationReference>(documentationObject);
-                                var typeDocumentationReference = (TypeDocumentationReference)documentationObject;
-                                Assert.False(typeDocumentationReference.IsGeneric);
-                                Assert.Equal("Doki.TestAssembly.InheritanceChain.Abstractions.AbstractClass",
-                                    typeDocumentationReference.FullName);
-                                Assert.True(typeDocumentationReference.IsDocumented);
-                                Assert.False(typeDocumentationReference.IsMicrosoft);
-                            },
-                            documentationObject =>
-                            {
-                                Assert.NotNull(documentationObject);
-                                Assert.IsType<TextContent>(documentationObject);
-                                var textContent = (TextContent)documentationObject;
-                                Assert.Equal("for more information.", textContent.Text);
-                                Assert.Equal(DocumentationContentType.Text, documentationObject.ContentType);
-                                Assert.Equal("text", documentationObject.Id);
+                                Assert.Equal("summary", summary.Name);
+                                Assert.Equal("summary", summary.Id);
+                                Assert.Equal(DocumentationContentType.Xml, summary.ContentType);
+                                Assert.Collection(summary.Contents,
+                                    documentationObject =>
+                                    {
+                                        Assert.NotNull(documentationObject);
+                                        Assert.IsType<TextContent>(documentationObject);
+                                        var textContent = (TextContent)documentationObject;
+                                        Assert.Equal("This is an abstract class. See", textContent.Text);
+                                        Assert.Equal(DocumentationContentType.Text, documentationObject.ContentType);
+                                        Assert.Equal("text", documentationObject.Id);
+                                    },
+                                    documentationObject =>
+                                    {
+                                        Assert.NotNull(documentationObject);
+                                        Assert.IsType<TypeDocumentationReference>(documentationObject);
+                                        var typeDocumentationReference =
+                                            (TypeDocumentationReference)documentationObject;
+                                        Assert.False(typeDocumentationReference.IsGeneric);
+                                        Assert.Equal("Doki.TestAssembly.InheritanceChain.Abstractions.AbstractClass",
+                                            typeDocumentationReference.FullName);
+                                        Assert.True(typeDocumentationReference.IsDocumented);
+                                        Assert.False(typeDocumentationReference.IsMicrosoft);
+                                    },
+                                    documentationObject =>
+                                    {
+                                        Assert.NotNull(documentationObject);
+                                        Assert.IsType<TextContent>(documentationObject);
+                                        var textContent = (TextContent)documentationObject;
+                                        Assert.Equal("for more information.", textContent.Text);
+                                        Assert.Equal(DocumentationContentType.Text, documentationObject.ContentType);
+                                        Assert.Equal("text", documentationObject.Id);
+                                    });
                             });
                     });
             });


### PR DESCRIPTION
- Introduce `Doki.Extensions` package including the `TryGetParent` extension method
- Move `Remarks` and `Examples` xml documentation properties from `TypeDocumentationReference` to `MemberDocumentation` to support xml documentation on all kind of members
- Remove `Summary` xml documentation property from `MemberDocumentation`
- Add `Summaries` xml documentation property to `MemberDocumentation` to support multiple `summary` xml elements